### PR TITLE
Update loop start timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,7 @@
         usernameModal.style.display = "none";
         renderShop();
         renderStats();
+        lastTime = Date.now();
         loop();
         setInterval(postStats, 60000);
       } else {
@@ -492,6 +493,7 @@
       hideUsernameModal();
       renderShop();
       renderStats();
+      lastTime = Date.now();
       loop();
       setInterval(postStats, 60000);
     });


### PR DESCRIPTION
## Summary
- avoid a long first frame by resetting `lastTime` right before starting the game loop

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684c6ce4ded4832fbebf94db6e598192